### PR TITLE
manywheel: add _GLIBCXX_USE_CXX11_ABI=1 support for linux wheels

### DIFF
--- a/manywheel/Dockerfile_cxx11-abi
+++ b/manywheel/Dockerfile_cxx11-abi
@@ -1,0 +1,54 @@
+FROM ubuntu:18.04 as base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get clean && apt-get update
+RUN apt-get install -y curl locales git-all autoconf automake make cmake wget unzip vim gcc g++
+
+RUN locale-gen en_US.UTF-8
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Install openssl
+FROM base as openssl
+ADD ./common/install_openssl.sh install_openssl.sh
+RUN bash ./install_openssl.sh && rm install_openssl.sh
+
+# Install python
+FROM base as python
+ADD common/install_cpython.sh install_cpython.sh
+RUN apt-get update -y && \
+    apt-get install build-essential gdb lcov libbz2-dev libffi-dev \
+        libgdbm-dev liblzma-dev libncurses5-dev libreadline6-dev \
+        libsqlite3-dev libssl-dev lzma lzma-dev tk-dev uuid-dev zlib1g-dev -y && \
+    bash ./install_cpython.sh && \
+    rm install_cpython.sh && \
+    apt-get clean
+
+FROM base as intel
+# Install MKL
+ADD ./common/install_mkl.sh install_mkl.sh
+RUN bash ./install_mkl.sh && rm install_mkl.sh
+
+FROM base as conda
+ADD ./common/install_conda.sh install_conda.sh
+RUN bash ./install_conda.sh && rm install_conda.sh
+RUN /opt/conda/bin/conda install -y cmake=3.14
+
+FROM base as final
+# Install LLVM
+COPY --from=pytorch/llvm:9.0.1 /opt/llvm              /opt/llvm
+COPY --from=pytorch/llvm:9.0.1 /opt/llvm_no_cxx11_abi /opt/llvm_no_cxx11_abi
+COPY --from=openssl            /opt/openssl           /opt/openssl
+# Install patchelf
+ADD ./common/install_patchelf.sh install_patchelf.sh
+RUN bash ./install_patchelf.sh && rm install_patchelf.sh
+COPY --from=intel              /opt/intel             /opt/intel
+# Install Anaconda
+COPY --from=conda              /opt/conda             /opt/conda
+# Install python
+COPY --from=python             /opt/python            /opt/python
+COPY --from=python             /opt/_internal         /opt/_internal
+ENV PATH /opt/conda/bin:$PATH

--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -15,7 +15,7 @@ case "${GPU_ARCH_TYPE:-BLANK}" in
     rocm)
         bash "${SCRIPTPATH}/build_rocm.sh"
         ;;
-    cpu)
+    cpu | cpu-cxx11-abi)
         bash "${SCRIPTPATH}/build_cpu.sh"
         ;;
     *)

--- a/manywheel/build_all_docker.sh
+++ b/manywheel/build_all_docker.sh
@@ -7,6 +7,8 @@ TOPDIR=$(git rev-parse --show-toplevel)
 GPU_ARCH_TYPE=cpu "${TOPDIR}/manywheel/build_docker.sh"
 MANYLINUX_VERSION=2014 GPU_ARCH_TYPE=cpu "${TOPDIR}/manywheel/build_docker.sh"
 
+GPU_ARCH_TYPE=cpu-cxx11-abi "${TOPDIR}/manywheel/build_docker.sh"
+
 for cuda_version in 11.5 11.3 10.2; do
     GPU_ARCH_TYPE=cuda GPU_ARCH_VERSION="${cuda_version}" "${TOPDIR}/manywheel/build_docker.sh"
     MANYLINUX_VERSION=2014 GPU_ARCH_TYPE=cuda GPU_ARCH_VERSION="${cuda_version}" "${TOPDIR}/manywheel/build_docker.sh"

--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -20,6 +20,14 @@ case ${GPU_ARCH_TYPE} in
         GPU_IMAGE=centos:7
         DOCKER_GPU_BUILD_ARG=""
         ;;
+    cpu-cxx11-abi)
+        TARGET=final
+        DOCKER_TAG=cpu-cxx11-abi
+        LEGACY_DOCKER_IMAGE=${DOCKER_REGISTRY}/pytorch/manylinux-cpu-cxx11-abi
+        GPU_IMAGE=""
+        DOCKER_GPU_BUILD_ARG=""
+        MANY_LINUX_VERSION="cxx11-abi"
+        ;;
     cuda)
         TARGET=cuda_final
         DOCKER_TAG=cuda${GPU_ARCH_VERSION}


### PR DESCRIPTION
The target of this commit is to add the support for a new linux
pip wheel file built with _GLIBCXX_USE_CXX11_ABI=1.

Currently, linux wheels are built in a system based on CentOS7
and devtoolset7, and CXX11_ABI is ignored by the compiler. The
same issue for devtoolset8 and devtoolset9, and so we add a Docker
file (Dockerfile_cxx11-abi) with Ubuntu 18.04 as base image to
support CXX11_ABI=1, by referring the Dockerfile for libtorch.

To build the new docker image with CXX11_ABI support, run:
GPU_ARCH_TYPE=cpu-cxx11-abi manywheel/build_docker.sh
or
manywheel/build_all_docker.sh

To build a new linux pip wheel file within this image, run:
// the below settings are special for this image
export DESIRED_CUDA=cpu-cxx11-abi   # change from cpu?
export GPU_ARCH_TYPE=cpu-cxx11-abi  # change from cpu?
export DOCKER_IMAGE=pytorch/manylinuxcxx11-abi-builder:cpu-cxx11-abi
export DESIRED_DEVTOOLSET=cxx11-abi

// the below settings are as usual
export BINARY_ENV_FILE=/tmp/env
export BUILDER_ROOT=/builder
export DESIRED_PYTHON=3.7   # or 3.8, 3.9, etc.
export IS_GHA=1
export PACKAGE_TYPE=manywheel
export PYTORCH_FINAL_PACKAGE_DIR=/artifacts
export PYTORCH_ROOT=/pytorch

// the '-e DESIRED_DEVTOOLSET' below is special for this container
set -x
  mkdir -p artifacts/
  container_name=$(docker run \
    ... \
    -e DESIRED_DEVTOOLSET \
    -v "${GITHUB_WORKSPACE}/pytorch:/pytorch" \
    -v "${GITHUB_WORKSPACE}/builder:/builder" \
    -v "${RUNNER_TEMP}/artifacts:/artifacts" \
    -w / \
    "${DOCKER_IMAGE}"
  )

// build pip wheel as usual,
// and the built wheel file name looks like: ???
docker exec -t -w "${PYTORCH_ROOT}" "${container_name}" bash -c "bash .circleci/scripts/binary_populate_env.sh"
docker exec -t "${container_name}" bash -c "source ${BINARY_ENV_FILE} && bash /builder/manywheel/build.sh"

// to verify the built wheel file, we'll see 'True' as output
$ pip install ...
$ python -c 'import torch; print(torch._C._GLIBCXX_USE_CXX11_ABI)'
True

Co-authored-by: Guo Yejun <yejun.guo@intel.com>
Co-authored-by: Zhu Hong <hong.zhu@intel.com>